### PR TITLE
Add char tests

### DIFF
--- a/backend/src/BackendOnlyStdLib/LibDB.fs
+++ b/backend/src/BackendOnlyStdLib/LibDB.fs
@@ -298,6 +298,7 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated }
 
+
     { name = fn "DB" "getAllWithKeys" 2
       parameters = [ tableParam ]
       returnType = TDict(varA)

--- a/backend/src/BackendOnlyStdLib/LibDB.fs
+++ b/backend/src/BackendOnlyStdLib/LibDB.fs
@@ -298,7 +298,6 @@ let fns : List<BuiltInFn> =
       previewable = Impure
       deprecated = NotDeprecated }
 
-
     { name = fn "DB" "getAllWithKeys" 2
       parameters = [ tableParam ]
       returnType = TDict(varA)

--- a/backend/src/LibBackend/SqlCompiler.fs
+++ b/backend/src/LibBackend/SqlCompiler.fs
@@ -39,6 +39,7 @@ let typeToSqlType (t : DType) : string =
   | TFloat -> "double precision"
   | TBool -> "bool"
   | TDate -> "timestamp with time zone"
+  | TChar -> "character"
   | _ -> error $"We do not support this type of DB field yet: {t}"
 
 // This canonicalizes an expression, meaning it removes multiple ways of
@@ -263,6 +264,11 @@ let rec lambdaToSql
 
   | EString (_, v) ->
     typecheck $"string \"{v}\"" TStr expectedType
+    let name = randomString 10
+    $"(@{name})", [ name, Sql.string v ]
+
+  | ECharacter (_, v) ->
+    typecheck $"char '{v}'" TChar expectedType
     let name = randomString 10
     $"(@{name})", [ name, Sql.string v ]
 

--- a/backend/src/LibBackend/SqlCompiler.fs
+++ b/backend/src/LibBackend/SqlCompiler.fs
@@ -39,7 +39,7 @@ let typeToSqlType (t : DType) : string =
   | TFloat -> "double precision"
   | TBool -> "bool"
   | TDate -> "timestamp with time zone"
-  | TChar -> "character"
+  | TChar -> "text"
   | _ -> error $"We do not support this type of DB field yet: {t}"
 
 // This canonicalizes an expression, meaning it removes multiple ways of
@@ -380,6 +380,7 @@ let partiallyEvaluate
               | EUnit _
               | EFloat _
               | EString _
+              | ECharacter _
               | EVariable _ -> true
               | _ -> false)
             args

--- a/backend/src/LibBackend/UserDB.fs
+++ b/backend/src/LibBackend/UserDB.fs
@@ -91,6 +91,7 @@ and typeCheck (db : RT.DB.T) (obj : RT.DvalMap) : RT.DvalMap =
         | RT.TInt, RT.DInt _ -> value
         | RT.TFloat, RT.DFloat _ -> value
         | RT.TStr, RT.DStr _ -> value
+        | RT.TChar, RT.DChar _ -> value
         | RT.TBool, RT.DBool _ -> value
         | RT.TDate, RT.DDate _ -> value
         // CLEANUP use the inner type
@@ -138,7 +139,6 @@ and set
   : Task<Uuid> =
   let id = System.Guid.NewGuid()
   let merged = typeCheck db vals
-
   let upsertQuery =
     if upsert then
       "ON CONFLICT ON CONSTRAINT user_data_key_uniq DO UPDATE SET data = EXCLUDED.data"

--- a/backend/src/LibBackend/UserDB.fs
+++ b/backend/src/LibBackend/UserDB.fs
@@ -139,6 +139,7 @@ and set
   : Task<Uuid> =
   let id = System.Guid.NewGuid()
   let merged = typeCheck db vals
+
   let upsertQuery =
     if upsert then
       "ON CONFLICT ON CONSTRAINT user_data_key_uniq DO UPDATE SET data = EXCLUDED.data"

--- a/backend/src/LibExecution/ProgramTypesParser.fs
+++ b/backend/src/LibExecution/ProgramTypesParser.fs
@@ -166,6 +166,8 @@ module DType =
         match String.toLowercase listTyp with
         | "str" -> Some(PT.TDbList PT.TStr)
         | "string" -> Some(PT.TDbList PT.TStr)
+        | "char" -> Some(PT.TDbList PT.TChar)
+        | "character" -> Some(PT.TDbList PT.TChar)
         | "int" -> Some(PT.TDbList PT.TInt)
         | "integer" -> Some(PT.TDbList PT.TInt)
         | "float" -> Some(PT.TDbList PT.TFloat)

--- a/backend/src/LibExecutionStdLib/LibChar.fs
+++ b/backend/src/LibExecutionStdLib/LibChar.fs
@@ -128,7 +128,7 @@ let fns : List<BuiltInFn> =
       fn =
         function
         | _, [ DChar c1; DChar c2 ] ->
-          (if c1 < c2 then true else false) |> DBool |> Ply
+          (c1 < c2) |> DBool |> Ply
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -141,7 +141,7 @@ let fns : List<BuiltInFn> =
       fn =
         function
         | _, [ DChar c1; DChar c2 ] ->
-          (if c1 > c2 then true else false) |> DBool |> Ply
+          (c1 > c2) |> DBool |> Ply
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplemented
       previewable = Pure

--- a/backend/src/LibExecutionStdLib/LibChar.fs
+++ b/backend/src/LibExecutionStdLib/LibChar.fs
@@ -119,4 +119,31 @@ let fns : List<BuiltInFn> =
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplemented
       previewable = Pure
-      deprecated = NotDeprecated } ]
+      deprecated = NotDeprecated }
+
+    { name = fn "Char" "isLessThan" 0
+      parameters = [ Param.make "c1" TChar ""; Param.make "c2" TChar "" ]
+      returnType = TBool
+      description = "Return whether <param c1> is less than <param c2>"
+      fn =
+        function
+        | _, [ DChar c1; DChar c2 ] ->
+          (if c1 < c2 then true else false) |> DBool |> Ply
+        | _ -> incorrectArgs ()
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      deprecated = NotDeprecated }
+
+    { name = fn "Char" "isGreaterThan" 0
+      parameters = [ Param.make "c1" TChar ""; Param.make "c2" TChar "" ]
+      returnType = TBool
+      description = "Return whether <param c1> is greater than <param c2>"
+      fn =
+        function
+        | _, [ DChar c1; DChar c2 ] ->
+          (if c1 > c2 then true else false) |> DBool |> Ply
+        | _ -> incorrectArgs ()
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      deprecated = NotDeprecated }]
+

--- a/backend/src/LibExecutionStdLib/LibChar.fs
+++ b/backend/src/LibExecutionStdLib/LibChar.fs
@@ -127,8 +127,7 @@ let fns : List<BuiltInFn> =
       description = "Return whether <param c1> is less than <param c2>"
       fn =
         function
-        | _, [ DChar c1; DChar c2 ] ->
-          (c1 < c2) |> DBool |> Ply
+        | _, [ DChar c1; DChar c2 ] -> (c1 < c2) |> DBool |> Ply
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -140,10 +139,8 @@ let fns : List<BuiltInFn> =
       description = "Return whether <param c1> is greater than <param c2>"
       fn =
         function
-        | _, [ DChar c1; DChar c2 ] ->
-          (c1 > c2) |> DBool |> Ply
+        | _, [ DChar c1; DChar c2 ] -> (c1 > c2) |> DBool |> Ply
         | _ -> incorrectArgs ()
       sqlSpec = NotYetImplemented
       previewable = Pure
-      deprecated = NotDeprecated }]
-
+      deprecated = NotDeprecated } ]

--- a/backend/src/Parser/RTShortcuts.fs
+++ b/backend/src/Parser/RTShortcuts.fs
@@ -59,7 +59,7 @@ let ePipeApply (fnVal : Expr) (args : List<Expr>) : Expr =
 
 let eStr (str : string) : Expr = EString(gid (), str)
 
-let eChar (c : char) : Expr = ECharacter(gid (), c)
+let eChar (c : string) : Expr = ECharacter(gid (), c)
 
 let eInt (i : int) : Expr = EInteger(gid (), int64 i)
 

--- a/backend/src/Parser/RTShortcuts.fs
+++ b/backend/src/Parser/RTShortcuts.fs
@@ -59,6 +59,8 @@ let ePipeApply (fnVal : Expr) (args : List<Expr>) : Expr =
 
 let eStr (str : string) : Expr = EString(gid (), str)
 
+let eChar (c : char) : Expr = ECharacter(gid (), c)
+
 let eInt (i : int) : Expr = EInteger(gid (), int64 i)
 
 let eBlank () : Expr = EBlank(gid ())

--- a/backend/testfiles/execution/char.tests
+++ b/backend/testfiles/execution/char.tests
@@ -152,6 +152,7 @@ Char.isLessThan_v0 '2' '1' = false
 Char.isLessThan_v0 'a' (smiley null) = true
 Char.isLessThan_v0 'a' (hand null) = true
 Char.isLessThan_v0 'a' (family null) = true
+Char.isLessThan_v0 (smiley null) (hand null) = false
 
 
 Char.isGreaterThan_v0 'a' 'b' = false
@@ -170,3 +171,5 @@ Char.isGreaterThan_v0 '2' '1' = true
 Char.isGreaterThan_v0 'a' (smiley null) = false
 Char.isGreaterThan_v0 'a' (hand null) = false
 Char.isGreaterThan_v0 'a' (family null) = false
+Char.isGreaterThan_v0 (smiley null) (hand null) = true
+

--- a/backend/testfiles/execution/char.tests
+++ b/backend/testfiles/execution/char.tests
@@ -149,7 +149,6 @@ Char.isLessThan_v0 'a' ' ' = false
 Char.isLessThan_v0 'a' '\t' = false
 Char.isLessThan_v0 'a' '1' = false
 Char.isLessThan_v0 '2' '1' = false
-Char.isLessThan_v0 '2' '1' = false
 Char.isLessThan_v0 'a' (smiley null) = true
 Char.isLessThan_v0 'a' (hand null) = true
 Char.isLessThan_v0 'a' (family null) = true
@@ -167,7 +166,7 @@ Char.isGreaterThan_v0 'a' 'Ł' = false
 Char.isGreaterThan_v0 'a' ' ' = true
 Char.isGreaterThan_v0 'a' '\t' = true
 Char.isGreaterThan_v0 'a' '1' = true
+Char.isGreaterThan_v0 '2' '1' = true
 Char.isGreaterThan_v0 'a' (smiley null) = false
 Char.isGreaterThan_v0 'a' (hand null) = false
 Char.isGreaterThan_v0 'a' (family null) = false
-

--- a/backend/testfiles/execution/char.tests
+++ b/backend/testfiles/execution/char.tests
@@ -4,6 +4,9 @@
 [fn.hand null:any]
 ((String.toList_v1 "✋🏿") |> List.head_v2_ster)
 
+[fn.family null:any]
+((String.toList_v1 "👩‍👩‍👧‍👦") |> List.head_v2_ster)
+
 [tests.all]
 
 Char.toLowercase_v1 'A' = 'a'
@@ -131,3 +134,38 @@ Char.isASCII_v0 'ჾ' = false
 Char.isASCII_v0 'Ჾ' = false
 Char.isASCII_v0 ' ' = true
 Char.isASCII_v0 '\t' = true
+
+
+Char.isLessThan_v0 'a' 'b' = true
+Char.isLessThan_v0 'a' 'A' = false
+Char.isLessThan_v0 'b' 'A' = false
+Char.isLessThan_v0 'a' 'á' = true
+Char.isLessThan_v0 'b' 'á' = true
+Char.isLessThan_v0 'a' 'ჾ' = true
+Char.isLessThan_v0 'a' 'Ჾ' = true
+Char.isLessThan_v0 'a' 'ł' = true
+Char.isLessThan_v0 'a' 'Ł' = true
+Char.isLessThan_v0 'a' ' ' = false
+Char.isLessThan_v0 'a' '\t' = false
+Char.isLessThan_v0 'a' '1' = false
+Char.isLessThan_v0 '2' '1' = false
+Char.isLessThan_v0 '2' '1' = false
+Char.isLessThan_v0 'a' (smiley null) = true
+Char.isLessThan_v0 'a' (hand null) = true
+Char.isLessThan_v0 'a' (family null) = true
+
+
+Char.isGreaterThan_v0 'a' 'b' = false
+Char.isGreaterThan_v0 'a' 'A' = true
+Char.isGreaterThan_v0 'b' 'A' = true
+Char.isGreaterThan_v0 'a' 'á' = false
+Char.isGreaterThan_v0 'b' 'á' = false
+Char.isGreaterThan_v0 'a' 'ჾ' = false
+Char.isGreaterThan_v0 'a' 'Ჾ' = false
+Char.isGreaterThan_v0 'a' 'ł' = false
+Char.isGreaterThan_v0 'a' 'Ł' = false
+Char.isGreaterThan_v0 'a' ' ' = true
+Char.isGreaterThan_v0 'a' '\t' = true
+Char.isGreaterThan_v0 'a' '1' = true
+Char.isGreaterThan_v0 'a' (smiley null) = false
+Char.isGreaterThan_v0 'a' (hand null) = false

--- a/backend/testfiles/execution/char.tests
+++ b/backend/testfiles/execution/char.tests
@@ -169,3 +169,5 @@ Char.isGreaterThan_v0 'a' '\t' = true
 Char.isGreaterThan_v0 'a' '1' = true
 Char.isGreaterThan_v0 'a' (smiley null) = false
 Char.isGreaterThan_v0 'a' (hand null) = false
+Char.isGreaterThan_v0 'a' (family null) = false
+

--- a/backend/testfiles/execution/db.tests
+++ b/backend/testfiles/execution/db.tests
@@ -4,6 +4,7 @@
 // e.g. DB "x" has column "x" of type "Str"
 // ------------
 [db.X { "x" : "Str" }]
+[db.Z { "x" : "Character" }]
 [db.Lists { "strs" : "[Str]" , "ints" : "[Int]" }]
 [db.Insensitive { "cOlUmNnAmE" : "Str" }]
 [db.XY { "x" : "Str", "y": "Str" }]
@@ -76,6 +77,11 @@ DB.schema_v1 SortedX = { x = "Str"; sortBy = "Int" }
 (let old = DB.set_v1 { x = "hello" } "hello" X in
  let newval = DB.set_v1 { x = "goodbye" } "hello" X in
  DB.getAllWithKeys_v2 X) = { hello = { x = "goodbye"} }
+
+[test.db.set char upsert] with DB Z
+(let old = DB.set_v1 { x = 'a' } "a" Z in
+ let newval = DB.set_v1 { x = 'b' } "a" Z in
+ DB.getAllWithKeys_v2 Z) = { a = { x = 'b' } }
 
 // ------------
 // Exact field queries
@@ -225,6 +231,10 @@ DB.schema_v1 SortedX = { x = "Str"; sortBy = "Int" }
 (let one = DB.set_v1 { x = "hello" } "one" X in
  let two = DB.set_v1 { x = "hello" } "two" X in
  DB.queryOneWithKey_v2 { x = "hello" } X) = Nothing
+
+[test.db.queryOneWithKey_v2 works] with DB Z
+(let one = DB.set_v1 { x = 'a' } "one" Z in
+ DB.queryOneWithKey_v2 { x = 'b' } Z) = Nothing
 
 // DB.delete
 [test.db.delete_v1 does delete] with DB X

--- a/backend/testfiles/execution/db.tests
+++ b/backend/testfiles/execution/db.tests
@@ -232,7 +232,7 @@ DB.schema_v1 SortedX = { x = "Str"; sortBy = "Int" }
  let two = DB.set_v1 { x = "hello" } "two" X in
  DB.queryOneWithKey_v2 { x = "hello" } X) = Nothing
 
-[test.db.queryOneWithKey_v2 works] with DB Z
+[test.db.queryOneWithKey_v2 char works] with DB Z
 (let one = DB.set_v1 { x = 'a' } "one" Z in
  DB.queryOneWithKey_v2 { x = 'b' } Z) = Nothing
 

--- a/backend/testfiles/execution/db.tests
+++ b/backend/testfiles/execution/db.tests
@@ -81,7 +81,7 @@ DB.schema_v1 SortedX = { x = "Str"; sortBy = "Int" }
 [test.db.set char upsert] with DB Z
 (let old = DB.set_v1 { x = 'a' } "a" Z in
  let newval = DB.set_v1 { x = 'b' } "a" Z in
- DB.getAllWithKeys_v2 Z) = { a = { x = 'b' } }
+ DB.getAllWithKeys_v2 Z) = { a = { x = 'b'} }
 
 // ------------
 // Exact field queries

--- a/backend/tests/FuzzTests/InternalJson.FuzzTests.fs
+++ b/backend/tests/FuzzTests/InternalJson.FuzzTests.fs
@@ -28,12 +28,10 @@ type Generator =
 
   static member String() : Arbitrary<string> = G.SafeUnicodeString
 
-  static member Expr() =
-    Arb.Default.Derive()
+  static member Expr() = Arb.Default.Derive()
 
 
-  static member MatchPattern() =
-    Arb.Default.Derive()
+  static member MatchPattern() = Arb.Default.Derive()
 
 
 

--- a/backend/tests/FuzzTests/InternalJson.FuzzTests.fs
+++ b/backend/tests/FuzzTests/InternalJson.FuzzTests.fs
@@ -30,21 +30,11 @@ type Generator =
 
   static member Expr() =
     Arb.Default.Derive()
-    |> Arb.filter (fun expr ->
-      match expr with
-      // characters are not supported in OCaml
-      // CLEANUP can be removed once OCaml gone
-      | PT.ECharacter _ -> false
-      | _ -> true)
+
 
   static member MatchPattern() =
     Arb.Default.Derive()
-    |> Arb.filter (fun pattern ->
-      match pattern with
-      // characters are not supported in OCaml
-      // CLEANUP can be removed once OCaml gone
-      | PT.MPCharacter _ -> false
-      | _ -> true)
+
 
 
 module Roundtrippable =

--- a/backend/tests/TestUtils/RTShortcuts.fs
+++ b/backend/tests/TestUtils/RTShortcuts.fs
@@ -59,6 +59,8 @@ let ePipeApply (fnVal : Expr) (args : List<Expr>) : Expr =
 
 let eStr (str : string) : Expr = EString(gid (), str)
 
+let eChar (c : string) : Expr = ECharacter(gid (), c)
+
 let eInt (i : int) : Expr = EInteger(gid (), int64 i)
 
 let eBlank () : Expr = EBlank(gid ())


### PR DESCRIPTION
Changelog:

```
Standard Library
- Add `Char::isLessThan_v0`, `Char::isGreaterThan_v0` functions
- Add char tests
```

Based on what source are the tests ordered? (in the #4628 PR from dark there is a commit that mentions ordering the tests based on a source)


Not sure how to handle chars in sqlCompiler because Npgsql.Fsharp doesn't support them.
While going through SqlCompiler.fs, I noticed that Char is added in some functions such as `dvalToSql` and `postTraversal,` but not in others like `typeToSqlType`, `lambdaToSql`, and `partiallyEvaluate`.

While going through the SqlCompiler.fs file, I made some notes that helped me develop a general understanding of its contents. However, there are still some aspects that I didn't fully grasp.https://spurious-individual-09f.notion.site/SqlCompiler-87d884c8003747f8a259866aa7bea297

In `db.tests`
To test updating and inserting Chars in a database, I wrote the following code, but it didn't work. I'm unsure if the test is written incorrectly or if the errors are due to Chars not being supported
`[db.Z { "x" : "Char" }]`

```
[test.db.set with char upsert] with DB Z
(let old = DB.set_v1 { x = 'a' } "a" Z in
let newval = DB.set_v1 { x = 'b' } "a" Z in
DB.getAllWithKeys_v1 Z) = [["a"; { x = 'b' }]]

```

I may not have understood this correctly, which is why I am unable to solve the issue. Any guidance to resolve it would be appreciated.