### PR TITLE
Only support true and false in If statements

### DIFF
--- a/backend/testfiles/execution/language.tests
+++ b/backend/testfiles/execution/language.tests
@@ -75,13 +75,13 @@ toString 5 = "5"
 
 
 [tests.if]
-(if true then "correct" else 0) = "correct")
-(if false then "" else "correct") = "correct")
-(if null then "" else "correct") = "correct")
-(if Test.typeError_v0 "msg" then "" else "") = Test.typeError_v0 "Expected boolean, got error")
-(if List.head_v2_ster [] then "" else "") = Test.errorRailValue_v0 Nothing)
+(if true then "correct" else 0) = "correct"
+(if false then "" else "correct") = "correct"
+(if null then "" else "") = Test.typeError_v0 "If only supports Booleans"
+(if Test.typeError_v0 "msg" then "" else "") = Test.typeError_v0 "Expected boolean, got error"
+(if List.head_v2_ster [] then "" else "") = Test.errorRailValue_v0 Nothing
 (if blank then "" else "") = blank
-(if 5 then "correct" else "") = "correct"
+(if 5 then "" else "") = Test.typeError_v0 "If only supports Booleans"
 
 [tests.and]
 (true && true) = true

--- a/backend/testfiles/execution/language.tests
+++ b/backend/testfiles/execution/language.tests
@@ -78,7 +78,7 @@ toString 5 = "5"
 (if true then "correct" else 0) = "correct"
 (if false then "" else "correct") = "correct"
 (if null then "" else "") = Test.typeError_v0 "If only supports Booleans"
-(if Test.typeError_v0 "msg" then "" else "") = Test.typeError_v0 "Expected boolean, got error"
+(if Test.typeError_v0 "msg" then "" else "") = Test.typeError_v0 "msg"
 (if List.head_v2_ster [] then "" else "") = Test.errorRailValue_v0 Nothing
 (if blank then "" else "") = blank
 (if 5 then "" else "") = Test.typeError_v0 "If only supports Booleans"
@@ -405,7 +405,7 @@ Option.map2_v0 (Just 10) "not an option" (fun (a,b) -> "1") = Test.typeError_v0 
 
 [tests.errorPropagation]
 List.head_v2 (Test.typeError_v0 "test") = Test.typeError_v0 "test"
-(if Test.typeError_v0 "test" then 5 else 6) = Test.typeError_v0 "Expected boolean, got error"
+(if Test.typeError_v0 "test" then 5 else 6) = Test.typeError_v0 "test"
 (List.head_v2 (Test.typeError_v0 "test")).field = Test.typeError_v0 "Attempting to access a field of something that isn't a record or dict, (it's a Error)."
 [ 5; 6; List.head_v2 (Test.typeError_v0 "test") ] = [5;6; Test.typeError_v0 "test"]
 [ 5; 6; Test.typeError_v0 "test"] = [ 5; 6; Test.typeError_v0 "test"]

--- a/backend/tests/Tests/Execution.Tests.fs
+++ b/backend/tests/Tests/Execution.Tests.fs
@@ -198,11 +198,11 @@ let testRecursionInEditor : Test =
   }
 
 let testIfPreview : Test =
+  let ifID = gid ()
+  let thenID = gid ()
+  let elseID = gid ()
   let f cond =
     task {
-      let ifID = gid ()
-      let thenID = gid ()
-      let elseID = gid ()
       let ast = EIf(ifID, cond, EString(thenID, "then"), EString(elseID, "else"))
       let! results = execSaveDvals "if-preview" [] [] ast
 
@@ -224,7 +224,7 @@ let testIfPreview : Test =
   //
   // - the first part is "what does the if/then expression evaluate to?"
   //   If the condition is 'truthy', then the expression will return "then"
-  //   Otherwise it willll turn "else"
+  //   Otherwise it will turn "else"
   //
   // - the other two parts correspond to the `then` and `else` branches of the if condition.
   //   if the first is an `ExecutedResult` and the second is a `NonExecutedResult`,
@@ -238,9 +238,9 @@ let testIfPreview : Test =
         AT.NonExecutedResult(DStr "then"),
         AT.ExecutedResult(DStr "else")))
       (eNull (),
-       (AT.ExecutedResult(DStr "else"),
+       (AT.ExecutedResult(DError(SourceID(7UL, ifID), "If only supports Booleans")),
         AT.NonExecutedResult(DStr "then"),
-        AT.ExecutedResult(DStr "else")))
+        AT.NonExecutedResult(DStr "else")))
       // fakevals
       (eFn "Test" "errorRailValue" 0 [ eConstructor "Nothing" [] ],
        (AT.ExecutedResult(DErrorRail(DOption None)),
@@ -250,18 +250,22 @@ let testIfPreview : Test =
        (AT.ExecutedResult(DIncomplete(SourceID(7UL, 999UL))),
         AT.NonExecutedResult(DStr "then"),
         AT.NonExecutedResult(DStr "else")))
+      (eFn "Test" "typeError" 0 [ eStr "test" ],
+       (AT.ExecutedResult(DError(SourceNone, "test")),
+        AT.NonExecutedResult(DStr "then"),
+        AT.NonExecutedResult(DStr "else")))
       // others are true
       (eBool true,
        (AT.ExecutedResult(DStr "then"),
         AT.ExecutedResult(DStr "then"),
         AT.NonExecutedResult(DStr "else")))
       (eInt 5,
-       (AT.ExecutedResult(DStr "then"),
-        AT.ExecutedResult(DStr "then"),
+       (AT.ExecutedResult(DError(SourceID(7UL, ifID), "If only supports Booleans")),
+        AT.NonExecutedResult(DStr "then"),
         AT.NonExecutedResult(DStr "else")))
       (eStr "test",
-       (AT.ExecutedResult(DStr "then"),
-        AT.ExecutedResult(DStr "then"),
+       (AT.ExecutedResult(DError(SourceID(7UL, ifID), "If only supports Booleans")),
+        AT.NonExecutedResult(DStr "then"),
         AT.NonExecutedResult(DStr "else"))) ]
 
 let testOrPreview : Test =


### PR DESCRIPTION
Changelog:

```
Language
- `if` expressions now only support Boolean values
```
