### PR TITLE
Update zip and unzip to use tuples

### DIFF
--- a/backend/testfiles/execution/README.md
+++ b/backend/testfiles/execution/README.md
@@ -45,9 +45,6 @@ indicator, are all a single test named "name", and should be parsed as one.
 which say "with DB DBNAME". (Only give DBs to tests which need them, as these
 tests need to be isolated and that's much slower)
 
-`[test.name]` indicates that the following lines, up until the next test
-indicator, are all a single test named "name", and should be parsed as one.
-
 `[test.name] with DB MyDB` is like `[test.name]`, where the DB previously
 defined as MyDB is available to the test. Cannot currently be used with
 `with Worker MyWorker` syntax.

--- a/backend/testfiles/execution/list.tests
+++ b/backend/testfiles/execution/list.tests
@@ -192,11 +192,10 @@ List.uniqueBy_v0 [1;1;1;1] (fun x -> x) = [ 1 ]
 List.uniqueBy_v0 [7;42;7;2;10] (fun x -> x) = [ 2; 7; 10; 42 ]
 List.uniqueBy_v0 [] (fun x -> x) = []
 
-List.unzip_v0 [[1;10];10;[3;30]] = Test.typeError_v0 "Expected the argument `pairs` to be a list with exactly two values, but it was `10`. It is of type Int instead of `List`"
-List.unzip_v0 [[1;10];[2;20];[3;30;40]] = Test.typeError_v0 "Expected the argument `pairs` to be a list with exactly two values, but it was `[\n  3, 30, 40\n]`. It has length 3 but should have length 2"
-List.unzip_v0 [[]] = Test.typeError_v0 "Expected the argument `pairs` to be a list with exactly two values, but it was `[]`. It has length 0 but should have length 2"
-List.unzip_v0 [[1;10];[2;20];[3;30]] = [ [ 1; 2; 3 ]; [ 10; 20; 30 ] ]
-List.unzip_v0 [[10;6]] = [[10],[6]]
+List.unzip_v0 [(1,10);10;(3,30)] = Test.typeError_v0 "Expected the argument `pairs` to be a tuple with exactly two values, but it was `10`. It is of type Int instead of `Tuple`"
+List.unzip_v0 [(1,10);(2,20);(3,30,40)] = Test.typeError_v0 "Expected the argument `pairs` to be a tuple with exactly two values, but it was `(\n  3, 30, 40\n)`. It has length 3 but should have length 2"
+List.unzip_v0 [(1,10);(2,20);(3,30)] = [ [ 1; 2; 3 ]; [ 10; 20; 30 ] ]
+List.unzip_v0 [(10,6)] = [[10],[6]]
 
 List.zipShortest_v0 [10;20;30] [1;2;3] = [ [ 10; 1 ]; [ 20; 2 ]; [ 30; 3 ] ]
 List.zipShortest_v0 [10;20] [1;2;3] = [ [ 10; 1 ]; [ 20; 2 ] ]
@@ -204,7 +203,6 @@ List.zipShortest_v0 ["b";"v";"z"] [] = []
 List.zipShortest_v0 [] ["b";"v";"z"] = []
 List.zipShortest_v0 [Test.typeError_v0 ""] [Just ""] = Test.typeError_v0 ""
 
-List.zip_v0 [10;20;30] [1;2;3] = Just [ [ 10; 1 ]; [ 20; 2 ]; [ 30; 3 ] ]
+List.zip_v0 [10;20;30] [1;2;3] = Just [ (10, 1); (20, 2); (30, 3) ]
 List.zip_v0 [10;20] [1;2;3] = Nothing
 List.zip_v0 [] [] = Just []
-List.zip_v0 [Test.typeError_v0 ""] [Just ""] = Test.justWithTypeError_v0 ""


### PR DESCRIPTION
Changelog:

```
Area of change
- Functions List.zip_v0 and List.unzip_v0
- Readme.md
```
## What is the problem/goal being addressed?
Replacing the temporary list-based solution on tuples. See issue [#3310](https://github.com/darklang/dark/issues/3310)
Deleting a duplicated text from Readme.md

## What is the solution to this problem?
Changing realization and tests

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
`LibList.fs `and` list.tests`

## How are you sure this works/how was this tested?
Passing tests 

## What is the reversion plan if this fails after shipping?
Rollback this commit 

## Has this information been included in the comments?
no
