### PR TITLE
Replacing list to tuple in List.zipShortest result

### DIFF
--- a/backend/src/LibExecutionStdLib/LibList.fs
+++ b/backend/src/LibExecutionStdLib/LibList.fs
@@ -1045,14 +1045,14 @@ let fns : List<BuiltInFn> =
     { name = fn "List" "zipShortest" 0
       parameters =
         [ Param.make "as" (TList varA) ""; Param.make "bs" (TList varB) "" ]
-      returnType = TList varA
+      returnType = TList(TTuple(varA, varB, []))
       description =
         "Returns a list of parallel pairs from <param as> and <param bs>.
 
         If the lists differ in length, values from the longer list are dropped.
 
         For example, if <param as> is {{[1,2]}} and <param bs> is
-        {{[\"x\",\"y\",\"z\"]}}, returns {{[[1,\"x\"], [2,\"y\"]]}}.
+        {{[\"x\",\"y\",\"z\"]}}, returns {{[(1,\"x\"), (2,\"y\")]}}.
 
         Use <fn List::zip> if you want to enforce equivalent lengths for <param as>
         and <param bs>.
@@ -1069,7 +1069,7 @@ let fns : List<BuiltInFn> =
           let l2 = List.take (int len) l2
 
           List.zip l1 l2
-          |> List.map (fun (val1, val2) -> Dval.list [ val1; val2 ])
+          |> List.map (fun (val1, val2) -> DTuple(val1, val2, []))
           |> Dval.list
           |> Ply
         | _ -> incorrectArgs ())

--- a/backend/testfiles/execution/list.tests
+++ b/backend/testfiles/execution/list.tests
@@ -198,11 +198,15 @@ List.unzip_v0 [[]] = Test.typeError_v0 "Expected the argument `pairs` to be a li
 List.unzip_v0 [[1;10];[2;20];[3;30]] = [ [ 1; 2; 3 ]; [ 10; 20; 30 ] ]
 List.unzip_v0 [[10;6]] = [[10],[6]]
 
-List.zipShortest_v0 [10;20;30] [1;2;3] = [ [ 10; 1 ]; [ 20; 2 ]; [ 30; 3 ] ]
-List.zipShortest_v0 [10;20] [1;2;3] = [ [ 10; 1 ]; [ 20; 2 ] ]
+List.zipShortest_v0 [10;20;30] [1;2;3] = [ (10, 1); (20, 2); (30, 3) ]
+List.zipShortest_v0 [10;20;30] ["a";"bc";"d"] = [ (10, "a"); (20, "bc"); (30, "d")]
+List.zipShortest_v0 [10;20] [1;2;3] = [ (10, 1); (20, 2) ]
+List.zipShortest_v0 [1;2;3] [10;20] = [ (1, 10); (2, 20) ]
+List.zipShortest_v0 [10;20] ["a";"bc";"d"] = [ (10, "a"); (20, "bc") ]
+List.zipShortest_v0 ["a";"bc";"d"] [10;20] = [ ("a", 10); ("bc", 20) ]
 List.zipShortest_v0 ["b";"v";"z"] [] = []
 List.zipShortest_v0 [] ["b";"v";"z"] = []
-List.zipShortest_v0 [Test.typeError_v0 ""] [Just ""] = Test.typeError_v0 ""
+
 
 List.zip_v0 [10;20;30] [1;2;3] = Just [ [ 10; 1 ]; [ 20; 2 ]; [ 30; 3 ] ]
 List.zip_v0 [10;20] [1;2;3] = Nothing


### PR DESCRIPTION
Changelog:

```
Area of change
- Function List.zipShortest
```
## What is the problem/goal being addressed?
Replacing the temporary list-based solution on tuples. See issue [#3310](https://github.com/darklang/dark/issues/3310)
Also, add a couple of test cases for `zipShortest`.

## What is the solution to this problem?
Changing realization and tests

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
`LibList.fs `and` list.tests`
