### PR TITLE
Replacing list on tuples for dict to/from list

### DIFF
--- a/backend/src/LibExecutionStdLib/LibDict.fs
+++ b/backend/src/LibExecutionStdLib/LibDict.fs
@@ -134,10 +134,10 @@ let fns : List<BuiltInFn> =
 
 
     { name = fn "Dict" "fromList" 0
-      parameters = [ Param.make "entries" (TList varA) "" ]
+      parameters = [ Param.make "entries" (TTuple (varA, varB, [])) "" ]
       returnType = TOption(TDict varA)
       description =
-        "Each value in <param entries> must be a {{[key, value]}} list, where <var
+        "Each value in <param entries> must be a {{(key, value)}} list, where <var
          key> is a <type String>.
 
          If <param entries> contains no duplicate keys, returns {{Just <var dict>}}
@@ -150,15 +150,15 @@ let fns : List<BuiltInFn> =
         | _, [ DList l ] ->
           let f acc e =
             match acc, e with
-            | Some acc, DList [ DStr k; _ ] when Map.containsKey k acc -> None
-            | Some acc, DList [ DStr k; value ] -> Some(Map.add k value acc)
+            | Some acc, DTuple (DStr k, _, _) when Map.containsKey k acc -> None
+            | Some acc, DTuple (DStr k, value,[]) -> Some(Map.add k value acc)
             | _,
               ((DIncomplete _
               | DError _) as dv) -> Errors.foundFakeDval dv
-            | Some _, DList [ k; _ ] ->
-              Exception.raiseCode (Errors.argumentWasnt "a string" "key" k)
+            | Some _, DTuple (k, _, []) ->
+                Exception.raiseCode (Errors.argumentWasnt "a string" "key" k)
             | Some _, _ ->
-              Exception.raiseCode "All list items must be `[key, value]`"
+                Exception.raiseCode "All list items must be `(key, value)`"
             | None, _ -> None
 
           let result = List.fold (Some Map.empty) f l

--- a/backend/src/LibExecutionStdLib/LibDict.fs
+++ b/backend/src/LibExecutionStdLib/LibDict.fs
@@ -84,14 +84,14 @@ let fns : List<BuiltInFn> =
 
     { name = fn "Dict" "toList" 0
       parameters = [ Param.make "dict" (TDict varA) "" ]
-      returnType = (TList varA)
+      returnType = (TList (TTuple (varA, varB, [])))
       description =
-        "Returns <param dict>'s entries as a list of {{[key, value]}} lists, in an arbitrary order. This function is the opposite of <fn Dict::fromList>"
+        "Returns <param dict>'s entries as a list of {{(key, value)}} tuples, in an arbitrary order. This function is the opposite of <fn Dict::fromList>"
       fn =
         (function
         | _, [ DObj o ] ->
           Map.toList o
-          |> List.map (fun (k, v) -> DList [ DStr k; v ])
+          |> List.map (fun (k, v) -> DTuple (DStr k, v, []))
           |> DList
           |> Ply
         | _ -> incorrectArgs ())
@@ -105,7 +105,7 @@ let fns : List<BuiltInFn> =
       returnType = TDict varA
       description =
         "Returns a <type dict> with <param entries>. Each value in <param entries>
-         must be a {{(key, value)}} list, where <var key> is a <type String>.
+         must be a {{(key, value)}} tuple, where <var key> is a <type String>.
 
          If <param entries> contains duplicate <var key>s, the last entry with that
          key will be used in the resulting dictionary (use <fn Dict::fromList> if you
@@ -137,7 +137,7 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "entries" (TTuple (varA, varB, [])) "" ]
       returnType = TOption(TDict varA)
       description =
-        "Each value in <param entries> must be a {{(key, value)}} list, where <var
+        "Each value in <param entries> must be a {{(key, value)}} tuple, where <var
          key> is a <type String>.
 
          If <param entries> contains no duplicate keys, returns {{Just <var dict>}}

--- a/backend/src/LibExecutionStdLib/LibDict.fs
+++ b/backend/src/LibExecutionStdLib/LibDict.fs
@@ -101,11 +101,11 @@ let fns : List<BuiltInFn> =
 
 
     { name = fn "Dict" "fromListOverwritingDuplicates" 0
-      parameters = [ Param.make "entries" (TList varA) "" ]
+      parameters = [ Param.make "entries" (TTuple (varA, varB, [])) "" ]
       returnType = TDict varA
       description =
         "Returns a <type dict> with <param entries>. Each value in <param entries>
-         must be a {{[key, value]}} list, where <var key> is a <type String>.
+         must be a {{(key, value)}} list, where <var key> is a <type String>.
 
          If <param entries> contains duplicate <var key>s, the last entry with that
          key will be used in the resulting dictionary (use <fn Dict::fromList> if you
@@ -118,12 +118,12 @@ let fns : List<BuiltInFn> =
 
           let f acc e =
             match e with
-            | DList [ DStr k; value ] -> Map.add k value acc
-            | DList [ k; _ ] ->
-              Exception.raiseCode (Errors.argumentWasnt "a string" "key" k)
+            | DTuple (DStr k, value, []) -> Map.add k value acc
+            | DTuple (k, _, []) ->
+                Exception.raiseCode (Errors.argumentWasnt "a string" "key" k)
             | (DIncomplete _
             | DError _) as dv -> Errors.foundFakeDval dv
-            | _ -> Exception.raiseCode "All list items must be `[key, value]`"
+            | _ -> Exception.raiseCode "All list items must be `(key, value)`"
 
           let result = List.fold Map.empty f l
           Ply(DObj result)

--- a/backend/testfiles/execution/dict.tests
+++ b/backend/testfiles/execution/dict.tests
@@ -8,12 +8,12 @@ Dict.filter_v1 { key1 = 1; key2 = 3 }  (fun (k, v) -> v < 2) = { key1 = 1 }
 Dict.filter_v1 {} (fun (k, v) -> 0) = {}
 Dict.filter_v1 { a = 1; b = 2; c = 3 } (fun (k, v) -> 2) = Test.typeError_v0 "Expected `fn` to return a Bool, but it returned `2`"
 
-Dict.fromListOverwritingDuplicates_v0 [["a";1];["b";2];["a";3]] = { b = 2 ; a = 3 }
-Dict.fromListOverwritingDuplicates_v0 [["a";1];["b";2];["c";3]] = { c = 3 ; b = 2 ; a= 1 }
+Dict.fromListOverwritingDuplicates_v0 [("duplicate_key",1); ("b",2); ("duplicate_key",3)] = { b = 2 ; duplicate_key = 3 }
+Dict.fromListOverwritingDuplicates_v0 [("a",1); ("b",2); ("c",3)] = { c = 3 ; b = 2 ; a= 1 }
 Dict.fromListOverwritingDuplicates_v0 [] = {}
-Dict.fromListOverwritingDuplicates_v0 [["a";1];["b";2];["c";3;3]] = Test.typeError_v0 "All list items must be `[key, value]`"
-Dict.fromListOverwritingDuplicates_v0 [[1;1]] = Test.typeError_v0 "Expected the argument `key` to be a string, but it was `1`"
-Dict.fromListOverwritingDuplicates_v0 [["a";1];2;["c";3]] = Test.typeError_v0 "All list items must be `[key, value]`"
+Dict.fromListOverwritingDuplicates_v0 [("a",1); ("b",2); ("c",3,3)]  = Test.typeError_v0 "All list items must be `(key, value)`"
+Dict.fromListOverwritingDuplicates_v0 [(1,1)] = Test.typeError_v0 "Expected the argument `key` to be a string, but it was `1`"
+Dict.fromListOverwritingDuplicates_v0 [("a",1); 2; ("c",3)] = Test.typeError_v0 "All list items must be `(key, value)`"
 Dict.fromListOverwritingDuplicates_v0 [Test.typeError_v0 ""] = Test.typeError_v0 ""
 
 Dict.fromList_v0 [("duplicate_key",1); ("b",2); ("duplicate_key",3)] = Nothing

--- a/backend/testfiles/execution/dict.tests
+++ b/backend/testfiles/execution/dict.tests
@@ -56,7 +56,7 @@ Dict.singleton_v0 "Content-Length" 1 = { ``Content-Length`` = 1 }
 Dict.size_v0 { a = 3; b = 1; c = 1 } = 3
 Dict.size_v0 {} = 0
 
-Dict.toList_v0 { a = 1; b = 2; c = 3 } = [ [ "a"; 1 ], [ "b"; 2 ], [ "c"; 3 ]]
+Dict.toList_v0 { a = 1; b = 2; c = 3 } = [ ("a", 1 ), ("b", 2), ("c", 3)]
 Dict.toList_v0 {} = []
 
 Dict.values_v0 { key1 = "val1" } = ["val1"]

--- a/backend/testfiles/execution/dict.tests
+++ b/backend/testfiles/execution/dict.tests
@@ -16,12 +16,12 @@ Dict.fromListOverwritingDuplicates_v0 [[1;1]] = Test.typeError_v0 "Expected the 
 Dict.fromListOverwritingDuplicates_v0 [["a";1];2;["c";3]] = Test.typeError_v0 "All list items must be `[key, value]`"
 Dict.fromListOverwritingDuplicates_v0 [Test.typeError_v0 ""] = Test.typeError_v0 ""
 
-Dict.fromList_v0 [["a";1];["b";2];["a";3]] = Nothing // duplicate key
-Dict.fromList_v0 [["a";1];["b";2];["c";3]] = Just { c = 3; b = 2; a = 1 }
-Dict.fromList_v0 [ ["Content-Length";0]; ["Server"; "dark"] ] = Just {``Content-Length`` = 0; Server = "dark"}
-Dict.fromList_v0 [["a";1];["b";2];["c";3;3]] = Test.typeError_v0 "All list items must be `[key, value]`"
-Dict.fromList_v0 [[1;1]] = Test.typeError_v0 "Expected the argument `key` to be a string, but it was `1`"
-Dict.fromList_v0 [["a";1];2;["c";3]] = Test.typeError_v0 "All list items must be `[key, value]`"
+Dict.fromList_v0 [("duplicate_key",1); ("b",2); ("duplicate_key",3)] = Nothing
+Dict.fromList_v0 [("a",1); ("b",2); ("c",3)] = Just { c = 3; b = 2; a = 1 }
+Dict.fromList_v0 [("Content-Length",0); ("Server", "dark") ] = Just {``Content-Length`` = 0; Server = "dark"}
+Dict.fromList_v0 [("a",1); ("b",2); ("c",3,3)] = Test.typeError_v0 "All list items must be `(key, value)`"
+Dict.fromList_v0 [(1,1)] = Test.typeError_v0 "Expected the argument `key` to be a string, but it was `1`"
+Dict.fromList_v0 [("a",1); 2; ("c",3)] = Test.typeError_v0 "All list items must be `(key, value)`"
 Dict.fromList_v0 [] = Just {}
 Dict.fromList_v0 [Test.typeError_v0 ""] = Test.typeError_v0 ""
 

--- a/backend/testfiles/execution/http.tests
+++ b/backend/testfiles/execution/http.tests
@@ -27,19 +27,19 @@ Http.forbidden_v0 = Http.response_v0 null 403
 
 Http.success_v0 {test = "test1"} = Http.response_v0 {test = "test1"} 200
 Http.success_v0 {``Content-Length`` = 0; Server = "darklang"} = Http.response_v0 {``Content-Length`` = 0; Server = "darklang"} 200
-Http.success_v0 {``Content-Length`` = 0; Server = "darklang"} = Http.response_v0 (Dict.fromListOverwritingDuplicates ([ ["Content-Length";0]; ["Server"; "darklang"] ])) 200
+Http.success_v0 {``Content-Length`` = 0; Server = "darklang"} = Http.response_v0 (Dict.fromListOverwritingDuplicates ([ ("Content-Length",0); ("Server","darklang") ])) 200
 
 Http.responseWithHtml_v0 {test = "test1"}  200 = Http.responseWithHeaders_v0 {test = "test1"}  {``Content-Type`` = "text/html"} 200
-Http.responseWithHtml_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromListOverwritingDuplicates ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/html"} 200
-Http.responseWithHtml_v0  {``Content-Length`` = 0; Server = "darklang"} 4503599627370496I = Http.responseWithHeaders_v0  (Dict.fromListOverwritingDuplicates ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/html"} 4503599627370496I
+Http.responseWithHtml_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromListOverwritingDuplicates ([ ("Content-Length",0); ("Server","darklang")] )) {``Content-Type`` = "text/html"} 200
+Http.responseWithHtml_v0  {``Content-Length`` = 0; Server = "darklang"} 4503599627370496I = Http.responseWithHeaders_v0  (Dict.fromListOverwritingDuplicates ([ ("Content-Length",0); ("Server","darklang") ])) {``Content-Type`` = "text/html"} 4503599627370496I
 
 Http.responseWithText_v0 {Connection = "Keep-Alive"}  200 = Http.responseWithHeaders_v0  {Connection = "Keep-Alive"} {``Content-Type`` = "text/plain"} 200
-Http.responseWithText_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromListOverwritingDuplicates ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/plain"} 200
-Http.responseWithText_v0  {``Content-Length`` = 0; Server = "darklang"} 4503599627370496I = Http.responseWithHeaders_v0  (Dict.fromListOverwritingDuplicates ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "text/plain"} 4503599627370496I
+Http.responseWithText_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromListOverwritingDuplicates ([ ("Content-Length",0); ("Server","darklang") ])) {``Content-Type`` = "text/plain"} 200
+Http.responseWithText_v0  {``Content-Length`` = 0; Server = "darklang"} 4503599627370496I = Http.responseWithHeaders_v0  (Dict.fromListOverwritingDuplicates ([ ("Content-Length",0); ("Server","darklang")])) {``Content-Type`` = "text/plain"} 4503599627370496I
 
 Http.responseWithJson_v0 {Connection = "Keep-Alive"}  200 = Http.responseWithHeaders_v0  {Connection = "Keep-Alive"} {``Content-Type`` = "application/json"} 200
-Http.responseWithJson_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromListOverwritingDuplicates ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "application/json"} 200
-Http.responseWithJson_v0  {``Content-Length`` = 0; Server = "darklang"} 4503599627370496I = Http.responseWithHeaders_v0  (Dict.fromListOverwritingDuplicates ([ ["Content-Length";0]; ["Server";"darklang"] ])) {``Content-Type`` = "application/json"} 4503599627370496I
+Http.responseWithJson_v0  {``Content-Length`` = 0; Server = "darklang"} 200 = Http.responseWithHeaders_v0  (Dict.fromListOverwritingDuplicates ([ ("Content-Length",0); ("Server","darklang") ])) {``Content-Type`` = "application/json"} 200
+Http.responseWithJson_v0  {``Content-Length`` = 0; Server = "darklang"} 4503599627370496I = Http.responseWithHeaders_v0  (Dict.fromListOverwritingDuplicates ([ ("Content-Length",0); ("Server","darklang") ])) {``Content-Type`` = "application/json"} 4503599627370496I
 
 ((Http.response_v0 "" 4503599627370496I) |> toString) = "4503599627370496 {  }\n\"\""
 


### PR DESCRIPTION
Changelog:

```
Dict.fromList
Dict.toList
Dict.fromListOverwritingDuplicates
```
## What is the problem/goal being addressed?
Replacing the temporary list-based solution on tuples. See issue [#3310](https://github.com/darklang/dark/issues/3310)

## What is the solution to this problem?
Changing realization and tests

## What are the changes here? How do they solve the problem and what other product impacts do they cause?
`libDict.fs ` 
`list.tests`
`http.tests`

## How are you sure this works/how was this tested?
Passing tests 

## What is the reversion plan if this fails after shipping?
Rollback this commit 

## Has this information been included in the comments?
no
